### PR TITLE
[bug] - Open API 검색 결과가 없는 경우 예외처리

### DIFF
--- a/src/proxy/proxy.service.ts
+++ b/src/proxy/proxy.service.ts
@@ -52,8 +52,15 @@ export class ProxyService {
       )
     );
 
-    const { searchPoiInfo } = response.data;
+    if (response.data === '') {
+      return {
+        data: [],
+        totalCount: 0,
+        totalPage: 0,
+      };
+    }
 
+    const { searchPoiInfo } = response.data;
     const storeList = await this.generateStoreList(searchPoiInfo.pois.poi);
 
     return {

--- a/src/types/tmap.ts
+++ b/src/types/tmap.ts
@@ -113,16 +113,18 @@ export interface RequestSearchPoiInfo {
   poiGroupYn?: 'Y' | 'N'; // default N, 상세 정보 링크 참고
 }
 
-export interface ResponseSearchPoiInfo {
-  searchPoiInfo: {
-    totalCount: string;
-    count: string;
-    page: string;
-    pois: {
-      poi: Poi[];
+export type ResponseSearchPoiInfo =
+  | ''
+  | {
+      searchPoiInfo: {
+        totalCount: string;
+        count: string;
+        page: string;
+        pois: {
+          poi: Poi[];
+        };
+      };
     };
-  };
-}
 
 export interface RequestPoiInfo {
   version: '1';


### PR DESCRIPTION
### Issue number
- close #12

### Description
- Open API 요청 시 검색 결과가 없는 경우 response.data는 빈문자열로 반환됩니다.
- 기존 코드에선 response.data의 데이터 타입을 객체로만 지정해주어, 위와 같이 빈문자열로 반환되는 경우 null 체크가 되지 않아 500 에러가 발생하게 되었습니다.
- 해당 이슈를 해결하기 위해 Open API의 응답 타입에 빈문자열을 추가해주어 서비스 로직에서 해당 조건인 경우 빈 배열을 반환하도록 수정하였습니다.

### Note
- 