### PR TITLE
[Feature] - 리뷰 신고 이력 변경 API 개발 (관리자용)

### DIFF
--- a/src/reviews/reviews.controller.ts
+++ b/src/reviews/reviews.controller.ts
@@ -18,6 +18,16 @@ export class ReviewsController {
     return this.reviewsService.report(id);
   }
 
+  @Patch(':id/unreport')
+  @ApiOperation({
+    summary: '신고된 리뷰 원복 (관리자용)',
+  })
+  @ApiParam({ name: 'id', required: true, type: 'string' })
+  @ApiResponse(responseExampleForReview.report)
+  unreport(@Param('id') id: string) {
+    return this.reviewsService.unreport(id);
+  }
+
   @Get()
   @ApiOperation({
     summary: '리뷰 목록 조회 (관리자용)',

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -67,14 +67,21 @@ export class ReviewsService {
   }
 
   async report(id: string) {
-    const review = await this.reviewRepository.findOneBy({ id });
-    if (!review) throw new NotFoundException(EXCEPTION.NOT_FOUND_REVIEW);
+    const review = await this.findOneById(id);
 
     review.isReported = true;
     await this.reviewRepository.update(id, review);
 
-    const reportedReview = await this.reviewRepository.findOneBy({ id });
-    return reportedReview;
+    return review;
+  }
+
+  async unreport(id: string) {
+    const review = await this.findOneById(id);
+
+    review.isReported = false;
+    await this.reviewRepository.update(id, review);
+
+    return review;
   }
 
   async delete(id: string) {
@@ -101,6 +108,13 @@ export class ReviewsService {
     } finally {
       await queryRunner.release();
     }
+  }
+
+  async findOneById(id: string) {
+    const review = await this.reviewRepository.findOneBy({ id });
+    if (!review) throw new NotFoundException(EXCEPTION.NOT_FOUND_REVIEW);
+
+    return review;
   }
 
   async list(take = DEFAULT_TAKE, skip = DEFAULT_SKIP, isReported = false) {


### PR DESCRIPTION
### Issue number
- close #16

### Description
- 신고된 리뷰를 원복하는 API를 개발했습니다.
    - 해당 API는 관리자 전용이며, 프론트엔드 서비스에서 호출되지 않습니다.
- 리뷰를 단건으로 조회하는 메소드를 개발하여 리뷰 신고, 신고원복 API에서 재사용하도록 구현하였습니다.
- swagger에 신고된 리뷰 원복 api를 추가하였습니다.

### Note
- 