### PR TITLE
[Feature] - 매장 좋아요 API 개발

### DIFF
--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,4 +1,6 @@
 export const EXCEPTION = {
   NOT_FOUND_STORE: '매장 정보를 찾을 수 없습니다.',
   NOT_FOUND_REVIEW: '리뷰 정보를 찾을 수 없습니다.',
+  REQUIRED_FIELD: (field: string) => `${field} 값이 필요합니다.`,
+  ALLOW_LIKE_ACTIONS: (value: string) => `'like' 또는 'unlike' 값만 허용됩니다. (입력값: ${value})`,
 };

--- a/src/constants/swagger.ts
+++ b/src/constants/swagger.ts
@@ -23,6 +23,7 @@ const storeResponse = {
   friendlyCount: 'number',
   valuableCount: 'number',
   comfortableCount: 'number',
+  likeCount: 'number',
   createdAt: 'date string',
   updatedAt: 'date string',
 };
@@ -59,6 +60,7 @@ export const responseExampleForStore = {
   }),
   detail: responseTemplate(storeResponse),
   changePaymentStatus: responseTemplate(storeResponse),
+  like: responseTemplate(storeResponse),
   delete: responseTemplate(deleteResponse),
 };
 

--- a/src/stores/dto/store-form.dto.ts
+++ b/src/stores/dto/store-form.dto.ts
@@ -6,6 +6,7 @@ export class StoreFormDTO extends OmitType(StoreEntity, [
   'friendlyCount',
   'valuableCount',
   'comfortableCount',
+  'likeCount',
   'createdAt',
   'updatedAt',
   'deletedAt',

--- a/src/stores/dto/store-like.dto.ts
+++ b/src/stores/dto/store-like.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+
+export enum LikeAction {
+  LIKE = 'like',
+  UNLIKE = 'unlike',
+}
+
+export class StoreLikeDTO {
+  @ApiProperty()
+  @IsEnum(LikeAction)
+  action: LikeAction;
+}

--- a/src/stores/stores.controller.ts
+++ b/src/stores/stores.controller.ts
@@ -1,12 +1,12 @@
 import { Controller, Get, Query, Post, Body, Param, Patch, Delete } from '@nestjs/common';
-import { ApiQuery, ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
+import { ApiQuery, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { StoresService } from './stores.service';
 import { StoreFormDTO } from './dto/store-form.dto';
 import { responseExampleForReview, responseExampleForStore } from 'src/constants/swagger';
 import { PaymentStatusFormDTO } from './dto/payment-status-form.dto';
 import { ReviewsService } from 'src/reviews/reviews.service';
 import { ReviewFormDTO } from 'src/reviews/dto/review-form.dto';
-import { LikeAction } from './stores.type';
+import { StoreLikeDTO } from './dto/store-like.dto';
 
 @ApiTags('Store')
 @Controller('stores')
@@ -71,13 +71,8 @@ export class StoresController {
   @ApiOperation({ summary: '매장 좋아요' })
   @ApiParam({ name: 'id', required: true, type: 'string' })
   @ApiResponse(responseExampleForStore.like)
-  @ApiBody({
-    schema: {
-      example: { action: 'like | unlike' },
-    },
-  })
-  likeStore(@Param('id') id: string, @Body() { action }: { action: LikeAction }) {
-    return this.storesService.like(id, action);
+  likeStore(@Param('id') id: string, @Body() storeLikeDto: StoreLikeDTO) {
+    return this.storesService.like(id, storeLikeDto);
   }
 
   @Post('/:storeId/reviews')

--- a/src/stores/stores.controller.ts
+++ b/src/stores/stores.controller.ts
@@ -1,11 +1,12 @@
 import { Controller, Get, Query, Post, Body, Param, Patch, Delete } from '@nestjs/common';
-import { ApiQuery, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { ApiQuery, ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
 import { StoresService } from './stores.service';
 import { StoreFormDTO } from './dto/store-form.dto';
 import { responseExampleForReview, responseExampleForStore } from 'src/constants/swagger';
 import { PaymentStatusFormDTO } from './dto/payment-status-form.dto';
 import { ReviewsService } from 'src/reviews/reviews.service';
 import { ReviewFormDTO } from 'src/reviews/dto/review-form.dto';
+import { LikeAction } from './stores.type';
 
 @ApiTags('Store')
 @Controller('stores')
@@ -64,6 +65,19 @@ export class StoresController {
   @ApiResponse(responseExampleForStore.delete)
   deleteStore(@Param('id') id: string) {
     return this.storesService.deleteStore(id);
+  }
+
+  @Patch('/:id/like')
+  @ApiOperation({ summary: '매장 좋아요' })
+  @ApiParam({ name: 'id', required: true, type: 'string' })
+  @ApiResponse(responseExampleForStore.like)
+  @ApiBody({
+    schema: {
+      example: { action: 'like | unlike' },
+    },
+  })
+  likeStore(@Param('id') id: string, @Body() { action }: { action: LikeAction }) {
+    return this.storesService.like(id, action);
   }
 
   @Post('/:storeId/reviews')

--- a/src/stores/stores.entity.ts
+++ b/src/stores/stores.entity.ts
@@ -73,4 +73,9 @@ export class StoreEntity extends CommonEntity {
   @IsNumber()
   @Column({ type: 'int', default: 0 })
   comfortableCount: number;
+
+  @ApiProperty()
+  @IsNumber()
+  @Column({ type: 'int', default: 0 })
+  likeCount: number;
 }

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -26,6 +26,7 @@ export class StoresService {
     const [stores, totalCount] = await this.storeRepository
       .createQueryBuilder('store')
       .orderBy({
+        'store.likeCount': 'DESC',
         'store.reviewCount': 'DESC',
         'store.paymentStatus': 'ASC',
         'store.id': 'ASC',

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -6,7 +6,7 @@ import { StoreFormDTO } from './dto/store-form.dto';
 import { StoreEntity } from './stores.entity';
 import { EXCEPTION } from 'src/constants/message';
 import { PaymentStatusFormDTO } from './dto/payment-status-form.dto';
-import { LikeAction } from './stores.type';
+import { LikeAction, StoreLikeDTO } from './dto/store-like.dto';
 
 @Injectable()
 export class StoresService {
@@ -65,10 +65,10 @@ export class StoresService {
     };
   }
 
-  async like(id: string, action: LikeAction) {
+  async like(id: string, storeLikeDto: StoreLikeDTO) {
     const store = await this.getStore(id);
 
-    if (action === 'like') store.likeCount += 1;
+    if (storeLikeDto.action === LikeAction.LIKE) store.likeCount += 1;
     else store.likeCount -= 1;
 
     await this.storeRepository.update(id, store);

--- a/src/stores/stores.service.ts
+++ b/src/stores/stores.service.ts
@@ -6,6 +6,7 @@ import { StoreFormDTO } from './dto/store-form.dto';
 import { StoreEntity } from './stores.entity';
 import { EXCEPTION } from 'src/constants/message';
 import { PaymentStatusFormDTO } from './dto/payment-status-form.dto';
+import { LikeAction } from './stores.type';
 
 @Injectable()
 export class StoresService {
@@ -61,5 +62,16 @@ export class StoresService {
     return {
       message: '삭제되었습니다.',
     };
+  }
+
+  async like(id: string, action: LikeAction) {
+    const store = await this.getStore(id);
+
+    if (action === 'like') store.likeCount += 1;
+    else store.likeCount -= 1;
+
+    await this.storeRepository.update(id, store);
+
+    return store;
   }
 }

--- a/src/stores/stores.type.ts
+++ b/src/stores/stores.type.ts
@@ -1,1 +1,0 @@
-export type LikeAction = 'like' | 'unlike';

--- a/src/stores/stores.type.ts
+++ b/src/stores/stores.type.ts
@@ -1,0 +1,1 @@
+export type LikeAction = 'like' | 'unlike';


### PR DESCRIPTION
### Issue number
- close #19

### Description
- 매장 좋아요 API 개발 (PATCH `/store/<store_id>/like`)

    - 매장 Entity likeCount Column 추가

    - Request body example
        ```json
        {
            "action": "like | unlike"
        }
        ```

    - `action` 값이 유효하지 않을 경우 400 에러 예외처리

- 매장 목록 조회 API 정렬 조건 변경

    - 변경 전 (as-is)
        - 1차 정렬: reviewCount
        - 2차 정렬: paymentStatus

    - 변경 후 (to-be)
        - 1차 정렬: likeCount
        - 2차 정렬: reviewCount
        - 3차 정렬: paymentStatus

- Swagger 갱신

### Note
- 