### PR TITLE
[Bug] - 프록시 매장 조회 API likeCount 필드 누락

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -14,4 +14,4 @@ WORKDIR /app
 
 COPY --from=builder /app ./
 
-ENTRYPOINT ["npm", "run", "start:prod"]
+ENTRYPOINT ["yarn", "start:prod"]

--- a/src/proxy/proxy.service.ts
+++ b/src/proxy/proxy.service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { AxiosError } from 'axios';
 import { catchError, firstValueFrom } from 'rxjs';
 import { DEFAULT_SKIP, DEFAULT_TAKE } from 'src/constants/page';
+import { StoreEntity } from 'src/stores/stores.entity';
 import { StoresService } from 'src/stores/stores.service';
 import { Store } from 'src/types/store';
 import { Poi, RequestSearchPoiInfo, ResponsePoiInfo, ResponseSearchPoiInfo } from 'src/types/tmap';
@@ -73,7 +74,9 @@ export class ProxyService {
   private async generateStoreList(poi: Poi[]) {
     const storeList = await Promise.all(
       poi.map<Promise<Store>>(async (item) => {
-        const existsStore = await this.storesService.getStore(item.id).catch(() => null);
+        const existsStore: StoreEntity | null = await this.storesService
+          .getStore(item.id)
+          .catch(() => null);
 
         return {
           id: item.id,
@@ -84,6 +87,7 @@ export class ProxyService {
           lon: item.newAddressList.newAddress[0].centerLon,
           paymentStatus: existsStore ? existsStore.paymentStatus : 'unregistered',
           reviewCount: existsStore ? existsStore.reviewCount : 0,
+          likeCount: existsStore ? existsStore.likeCount : 0,
         };
       })
     );
@@ -127,6 +131,7 @@ export class ProxyService {
       lon: poiDetailInfo.lon,
       paymentStatus: 'unregistered',
       reviewCount: 0,
+      likeCount: 0,
     };
 
     return store;

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -14,4 +14,5 @@ export interface Store {
   lon: string;
   paymentStatus: PaymentStatus;
   reviewCount: number;
+  likeCount: number;
 }


### PR DESCRIPTION
### Issue number
- close #22

### Description
- 프록시 매장 조회 시 누락된 likeCount 필드를 추가하였습니다.

### Note
- dockerfile의 entrypoint 명령어 부분에서 npm 패키지 매니저를 사용하고 있어, yarn으로 변경하였습니다.